### PR TITLE
Update to `egui` 0.31 and fix compatibility issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ nord = []
 tokyo_night = []
 
 [dependencies]
-egui = "0.28"
+egui = "0.31"
 
 [lib]
 name = "egui_aesthetix"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub trait Aesthetix {
     /// Using the same value will yield a more consistent look.
     ///
     /// - Egui default is 6.0
-    fn margin_style(&self) -> f32;
+    fn margin_style(&self) -> i8;
 
     /// Button size is text size plus this on each side.
     ///
@@ -100,7 +100,7 @@ pub trait Aesthetix {
     /// Custom rounding value for all buttons and frames.
     ///
     /// - Egui default is 4.0
-    fn rounding_visuals(&self) -> f32;
+    fn rounding_visuals(&self) -> u8;
 
     /// Controls the sizes and distances between widgets.
     /// The following types of spacing are implemented.
@@ -173,7 +173,7 @@ pub trait Aesthetix {
                 width: 1.0,
                 color: self.bg_auxiliary_color_visuals(),
             },
-            rounding: egui::Rounding {
+            corner_radius: egui::CornerRadius {
                 nw: self.rounding_visuals(),
                 ne: self.rounding_visuals(),
                 sw: self.rounding_visuals(),
@@ -196,7 +196,7 @@ pub trait Aesthetix {
                 width: 0.0,
                 color: egui::Color32::from_rgba_premultiplied(0, 0, 0, 0),
             },
-            rounding: egui::Rounding {
+            corner_radius: egui::CornerRadius {
                 nw: self.rounding_visuals(),
                 ne: self.rounding_visuals(),
                 sw: self.rounding_visuals(),
@@ -219,7 +219,7 @@ pub trait Aesthetix {
                 width: 1.0,
                 color: self.bg_triage_color_visuals(),
             },
-            rounding: egui::Rounding {
+            corner_radius: egui::CornerRadius {
                 nw: self.rounding_visuals(),
                 ne: self.rounding_visuals(),
                 sw: self.rounding_visuals(),
@@ -242,7 +242,7 @@ pub trait Aesthetix {
                 width: 1.0,
                 color: self.bg_primary_color_visuals(),
             },
-            rounding: egui::Rounding {
+            corner_radius: egui::CornerRadius {
                 nw: self.rounding_visuals(),
                 ne: self.rounding_visuals(),
                 sw: self.rounding_visuals(),
@@ -265,7 +265,7 @@ pub trait Aesthetix {
                 width: 1.0,
                 color: self.bg_triage_color_visuals(),
             },
-            rounding: egui::Rounding {
+            corner_radius: egui::CornerRadius {
                 nw: self.rounding_visuals(),
                 ne: self.rounding_visuals(),
                 sw: self.rounding_visuals(),
@@ -353,14 +353,14 @@ pub trait Aesthetix {
                 code_bg_color: self.bg_auxiliary_color_visuals(),
                 warn_fg_color: self.fg_warn_text_color_visuals(),
                 error_fg_color: self.fg_error_text_color_visuals(),
-                window_rounding: egui::Rounding {
+                window_corner_radius: egui::CornerRadius {
                     nw: self.rounding_visuals(),
                     ne: self.rounding_visuals(),
                     sw: self.rounding_visuals(),
                     se: self.rounding_visuals(),
                 },
                 window_shadow: egui::epaint::Shadow {
-                    spread: 32.0,
+                    spread: 32,
                     color: egui::Color32::from_rgba_premultiplied(0, 0, 0, 96),
                     ..Default::default()
                 },
@@ -369,14 +369,14 @@ pub trait Aesthetix {
                     width: 1.0,
                     color: self.bg_contrast_color_visuals(),
                 },
-                menu_rounding: egui::Rounding {
+                menu_corner_radius: egui::CornerRadius {
                     nw: self.rounding_visuals(),
                     ne: self.rounding_visuals(),
                     sw: self.rounding_visuals(),
                     se: self.rounding_visuals(),
                 },
                 popup_shadow: egui::epaint::Shadow {
-                    spread: 16.0,
+                    spread: 16,
                     color: egui::Color32::from_rgba_premultiplied(19, 18, 18, 96),
                     ..Default::default()
                 },

--- a/src/themes/carl/dark.rs
+++ b/src/themes/carl/dark.rs
@@ -7,7 +7,7 @@ use crate::Aesthetix;
 pub struct CarlDark;
 
 impl Aesthetix for CarlDark {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "Carl Dark"
     }
 
@@ -59,8 +59,8 @@ impl Aesthetix for CarlDark {
         true
     }
 
-    fn margin_style(&self) -> f32 {
-        12.0
+    fn margin_style(&self) -> i8 {
+        12
     }
 
     fn button_padding(&self) -> egui::Vec2 {
@@ -75,7 +75,7 @@ impl Aesthetix for CarlDark {
         14.0
     }
 
-    fn rounding_visuals(&self) -> f32 {
-        6.0
+    fn rounding_visuals(&self) -> u8 {
+        6
     }
 }

--- a/src/themes/nord/dark.rs
+++ b/src/themes/nord/dark.rs
@@ -8,7 +8,7 @@ use crate::Aesthetix;
 pub struct NordDark;
 
 impl Aesthetix for NordDark {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "Nord Dark"
     }
 
@@ -60,8 +60,8 @@ impl Aesthetix for NordDark {
         true
     }
 
-    fn margin_style(&self) -> f32 {
-        12.0
+    fn margin_style(&self) -> i8 {
+        12
     }
 
     fn button_padding(&self) -> egui::Vec2 {
@@ -76,7 +76,7 @@ impl Aesthetix for NordDark {
         14.0
     }
 
-    fn rounding_visuals(&self) -> f32 {
-        6.0
+    fn rounding_visuals(&self) -> u8 {
+        6
     }
 }

--- a/src/themes/nord/light.rs
+++ b/src/themes/nord/light.rs
@@ -8,7 +8,7 @@ use crate::Aesthetix;
 pub struct NordLight;
 
 impl Aesthetix for NordLight {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "Nord Light"
     }
 
@@ -60,8 +60,8 @@ impl Aesthetix for NordLight {
         false
     }
 
-    fn margin_style(&self) -> f32 {
-        12.0
+    fn margin_style(&self) -> i8 {
+        12
     }
 
     fn button_padding(&self) -> egui::Vec2 {
@@ -76,7 +76,7 @@ impl Aesthetix for NordLight {
         14.0
     }
 
-    fn rounding_visuals(&self) -> f32 {
-        6.0
+    fn rounding_visuals(&self) -> u8 {
+        6
     }
 }

--- a/src/themes/standard/dark.rs
+++ b/src/themes/standard/dark.rs
@@ -8,7 +8,7 @@ use crate::Aesthetix;
 pub struct StandardDark;
 
 impl Aesthetix for StandardDark {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "Standard Dark"
     }
 
@@ -60,8 +60,8 @@ impl Aesthetix for StandardDark {
         true
     }
 
-    fn margin_style(&self) -> f32 {
-        12.0
+    fn margin_style(&self) -> i8 {
+        12
     }
 
     fn button_padding(&self) -> egui::Vec2 {
@@ -76,7 +76,7 @@ impl Aesthetix for StandardDark {
         14.0
     }
 
-    fn rounding_visuals(&self) -> f32 {
-        6.0
+    fn rounding_visuals(&self) -> u8 {
+        6
     }
 }

--- a/src/themes/standard/light.rs
+++ b/src/themes/standard/light.rs
@@ -8,7 +8,7 @@ use crate::Aesthetix;
 pub struct StandardLight;
 
 impl Aesthetix for StandardLight {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "Standard Light"
     }
 
@@ -60,8 +60,8 @@ impl Aesthetix for StandardLight {
         false
     }
 
-    fn margin_style(&self) -> f32 {
-        12.0
+    fn margin_style(&self) -> i8 {
+        12
     }
 
     fn button_padding(&self) -> egui::Vec2 {
@@ -76,7 +76,7 @@ impl Aesthetix for StandardLight {
         14.0
     }
 
-    fn rounding_visuals(&self) -> f32 {
-        6.0
+    fn rounding_visuals(&self) -> u8 {
+        6
     }
 }

--- a/src/themes/tokyo_night/dark.rs
+++ b/src/themes/tokyo_night/dark.rs
@@ -7,7 +7,7 @@ use crate::Aesthetix;
 pub struct TokyoNight;
 
 impl Aesthetix for TokyoNight {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "Tokyo Night"
     }
 
@@ -59,8 +59,8 @@ impl Aesthetix for TokyoNight {
         true
     }
 
-    fn margin_style(&self) -> f32 {
-        12.0
+    fn margin_style(&self) -> i8 {
+        12
     }
 
     fn button_padding(&self) -> egui::Vec2 {
@@ -75,7 +75,7 @@ impl Aesthetix for TokyoNight {
         14.0
     }
 
-    fn rounding_visuals(&self) -> f32 {
-        6.0
+    fn rounding_visuals(&self) -> u8 {
+        6
     }
 }

--- a/src/themes/tokyo_night/storm.rs
+++ b/src/themes/tokyo_night/storm.rs
@@ -7,7 +7,7 @@ use crate::Aesthetix;
 pub struct TokyoNightStorm;
 
 impl Aesthetix for TokyoNightStorm {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "Tokyo Night Storm"
     }
 
@@ -59,8 +59,8 @@ impl Aesthetix for TokyoNightStorm {
         true
     }
 
-    fn margin_style(&self) -> f32 {
-        12.0
+    fn margin_style(&self) -> i8 {
+        12
     }
 
     fn button_padding(&self) -> egui::Vec2 {
@@ -75,7 +75,7 @@ impl Aesthetix for TokyoNightStorm {
         14.0
     }
 
-    fn rounding_visuals(&self) -> f32 {
-        6.0
+    fn rounding_visuals(&self) -> u8 {
+        6
     }
 }


### PR DESCRIPTION
Description:
- Updated `egui` dependency to `0.31`
- Fixed all compilation errors
- Replaced some `f32` types with `u8` and `i8` where required (due to `egui` changelogs)
- Renamed `rounding` properties to `corner_radius` to match `egui` `0.31` changes
Everything now compiles successfully with the latest `egui`.