### PR TITLE
Fix feature guards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,7 @@ match_wildcard_for_single_variants = { level = "allow", priority = 1 }
 unnested_or_patterns = { level = "allow", priority = 1 }
 similar_names = { level = "allow", priority = 1 }
 struct_field_names = { level = "allow", priority = 1 }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! A programmatic and Uniform approach to theming egui Applications.
 //!
 //! This library supplies one simple theme trait which attempts to expose all the key colors, margins, paddings, spacings
@@ -6,7 +8,6 @@
 //! It also gives defaults for more niche elements of the style that a user might not want to customize
 //! but can if they want to.
 
-#[cfg(feature = "default")]
 pub mod themes;
 
 /// Every custom egui theme that wishes to use the egui aesthetix crate must implement this trait.

--- a/src/themes/carl/mod.rs
+++ b/src/themes/carl/mod.rs
@@ -1,3 +1,5 @@
 //! Carl Dark theme, no light theme currently exists
 
-pub mod dark;
+mod dark;
+
+pub use dark::*;

--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -1,22 +1,22 @@
-//! All themes that the Aesthetix ships without of the box will
+//! All themes that the Aesthetix ships out of the box will
 //! be located in this folder
 
-mod carl;
-mod nord;
-mod standard;
-mod tokyo_night;
-
 #[cfg(feature = "carl")]
-pub use carl::dark::CarlDark;
+mod carl;
+#[cfg(feature = "carl")]
+pub use carl::*;
 
 #[cfg(feature = "nord")]
-pub use nord::dark::NordDark;
-pub use nord::light::NordLight;
+mod nord;
+#[cfg(feature = "nord")]
+pub use nord::*;
 
 #[cfg(feature = "tokyo_night")]
-pub use tokyo_night::dark::TokyoNight;
-pub use tokyo_night::storm::TokyoNightStorm;
+mod tokyo_night;
+#[cfg(feature = "tokyo_night")]
+pub use tokyo_night::*;
 
 #[cfg(feature = "standard")]
-pub use standard::dark::StandardDark;
-pub use standard::light::StandardLight;
+mod standard;
+#[cfg(feature = "standard")]
+pub use standard::*;

--- a/src/themes/nord/mod.rs
+++ b/src/themes/nord/mod.rs
@@ -1,4 +1,7 @@
 //! Nord Dark and Light themes
 
-pub mod dark;
-pub mod light;
+mod dark;
+mod light;
+
+pub use dark::*;
+pub use light::*;

--- a/src/themes/standard/mod.rs
+++ b/src/themes/standard/mod.rs
@@ -6,5 +6,8 @@
 //! structs are good examples on how to implement a theme you want using the
 //! [`egui_aesthetix::Aesthetix`] trait.
 
-pub mod dark;
-pub mod light;
+mod dark;
+mod light;
+
+pub use dark::*;
+pub use light::*;

--- a/src/themes/tokyo_night/mod.rs
+++ b/src/themes/tokyo_night/mod.rs
@@ -1,4 +1,7 @@
 //! Tokyo night dark, storm, and light themes,
 
-pub mod dark;
-pub mod storm;
+mod dark;
+mod storm;
+
+pub use dark::*;
+pub use storm::*;


### PR DESCRIPTION
There are two issues with feature guards currently:

1. When using the crate with `default-features = false`, the [feature guard in the `themes` module](https://github.com/thebashpotato/egui-aesthetix/blob/20ce3a5b098831ad5c3335e2b3814f5295573458/src/lib.rs#L9) will cause the `themes` module to be omitted, regardless of using `features = [...]`.
2. Themes [NordLight](https://github.com/thebashpotato/egui-aesthetix/blob/20ce3a5b098831ad5c3335e2b3814f5295573458/src/themes/mod.rs#L14), [TokyoNightStorm](https://github.com/thebashpotato/egui-aesthetix/blob/20ce3a5b098831ad5c3335e2b3814f5295573458/src/themes/mod.rs#L18) and [StandardLight](https://github.com/thebashpotato/egui-aesthetix/blob/20ce3a5b098831ad5c3335e2b3814f5295573458/src/themes/mod.rs#L22) are leaking, regardless of chosen features.

This PR solves issue 1 by removing the feature guard.

And it solves issue 2 by adding missing guards. (Note: `#[...]` attributes only apply to the immediate following item. It won't be applied to two consecutive `use` items, for example.)

It also changes a few other things:

* Changes all theme submodules visibility to private and pub re-export their items. The final result in `themes` module is still the same, but the submodules are now hidden internally in the crate itself.
* Adds docs.rs metadata in `Cargo.toml` and enables unstable feature `doc_auto_cfg` when generating documentation for docs.rs (`--cfg docsrs`). This will generate docs with a notice about `cfg(feature)` guards:

![Screenshot_20250302_003511](https://github.com/user-attachments/assets/99af12cf-5f23-49e7-99b0-c3b6e1814361)

![Screenshot_20250302_003959](https://github.com/user-attachments/assets/71cd2175-d628-49cb-9ec5-4933b3c70b5c)

To generate docs locally:

```sh
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --all-features
```

And it's possible to verify that feature guards are working by changing `--all-features` to `--no-default-features -F <feature>`.